### PR TITLE
refactor: category use case

### DIFF
--- a/ormconfig.json
+++ b/ormconfig.json
@@ -6,6 +6,7 @@
   "password": "ignite",
   "database": "rentx",
   "migrations": ["./src/database/migrations/*.ts"],
+  "entities": ["./src/modules/**/entities/*.ts"],
   "cli": {
     "migrationsDir": "./src/database/migrations"
   }

--- a/src/modules/cars/entities/Category.ts
+++ b/src/modules/cars/entities/Category.ts
@@ -1,7 +1,7 @@
 import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
 import { v4 as uuidV4 } from 'uuid';
 
-@Entity()
+@Entity('categories')
 class Category {
   @PrimaryColumn()
   id?: string;

--- a/src/modules/cars/repositories/ISpecificationsRepository.ts
+++ b/src/modules/cars/repositories/ISpecificationsRepository.ts
@@ -1,4 +1,4 @@
-import { Specification } from '../model/Specification';
+import { Specification } from '../entities/Specification';
 
 interface ICreateSpecificationDTO {
   name: string;

--- a/src/modules/cars/repositories/implementations/CategoriesRepository.ts
+++ b/src/modules/cars/repositories/implementations/CategoriesRepository.ts
@@ -9,18 +9,8 @@ import {
 class CategoriesRepository implements ICategoriesRepository {
   private repository: Repository<Category>;
 
-  private static INSTANCE: CategoriesRepository;
-
-  private constructor() {
+  constructor() {
     this.repository = getRepository(Category);
-  }
-
-  public static getInstance(): CategoriesRepository {
-    if (!CategoriesRepository.INSTANCE) {
-      CategoriesRepository.INSTANCE = new CategoriesRepository();
-    }
-
-    return CategoriesRepository.INSTANCE;
   }
 
   async create({ name, description }: ICreateCategoryDTO): Promise<void> {

--- a/src/modules/cars/repositories/implementations/SpecificationsRepository.ts
+++ b/src/modules/cars/repositories/implementations/SpecificationsRepository.ts
@@ -1,4 +1,4 @@
-import { Specification } from '../../model/Specification';
+import { Specification } from '../../entities/Specification';
 import {
   ISpecificationsRepository,
   ICreateSpecificationDTO,

--- a/src/modules/cars/useCases/createCategory/CreateCategoryController.ts
+++ b/src/modules/cars/useCases/createCategory/CreateCategoryController.ts
@@ -5,11 +5,11 @@ import { CreateCategoryUseCase } from './CreateCategoryUseCase';
 class CreateCategoryController {
   constructor(private createCategoryUseCase: CreateCategoryUseCase) {}
 
-  handle(request: Request, response: Response): Response {
+  async handle(request: Request, response: Response): Promise<Response> {
     try {
       const { name, description } = request.body;
 
-      this.createCategoryUseCase.execute({ name, description });
+      await this.createCategoryUseCase.execute({ name, description });
 
       return response.status(201).send();
     } catch (err) {

--- a/src/modules/cars/useCases/createCategory/CreateCategoryUseCase.ts
+++ b/src/modules/cars/useCases/createCategory/CreateCategoryUseCase.ts
@@ -8,8 +8,10 @@ interface IRequest {
 class CreateCategoryUseCase {
   constructor(private categoriesRepository: ICategoriesRepository) {}
 
-  execute({ name, description }: IRequest): void {
-    const categoryAlreadyExists = this.categoriesRepository.findByName(name);
+  async execute({ name, description }: IRequest): Promise<void> {
+    const categoryAlreadyExists = await this.categoriesRepository.findByName(
+      name
+    );
 
     if (categoryAlreadyExists) throw new Error('Category already exists!');
 

--- a/src/modules/cars/useCases/createCategory/index.ts
+++ b/src/modules/cars/useCases/createCategory/index.ts
@@ -2,10 +2,14 @@ import { CategoriesRepository } from '../../repositories/implementations/Categor
 import { CreateCategoryController } from './CreateCategoryController';
 import { CreateCategoryUseCase } from './CreateCategoryUseCase';
 
-const categoriesRepository = CategoriesRepository.getInstance();
-const createCategoryUseCase = new CreateCategoryUseCase(categoriesRepository);
-const createCategoryController = new CreateCategoryController(
-  createCategoryUseCase
-);
+export default (): CreateCategoryController => {
+  const categoriesRepository = new CategoriesRepository();
 
-export { createCategoryController };
+  const createCategoryUseCase = new CreateCategoryUseCase(categoriesRepository);
+
+  const createCategoryController = new CreateCategoryController(
+    createCategoryUseCase
+  );
+
+  return createCategoryController;
+};

--- a/src/modules/cars/useCases/importCategory/index.ts
+++ b/src/modules/cars/useCases/importCategory/index.ts
@@ -2,7 +2,7 @@ import { CategoriesRepository } from '../../repositories/implementations/Categor
 import { ImportCategoryController } from './ImportCategoryController';
 import { ImportCategoryUseCase } from './ImportCategoryUseCase';
 
-const categoriesRepository = CategoriesRepository.getInstance();
+const categoriesRepository = null;
 const importCategoryUseCase = new ImportCategoryUseCase(categoriesRepository);
 const importCategoryController = new ImportCategoryController(
   importCategoryUseCase

--- a/src/modules/cars/useCases/listCategories/ListCategoriesUseCase.ts
+++ b/src/modules/cars/useCases/listCategories/ListCategoriesUseCase.ts
@@ -1,4 +1,4 @@
-import { Category } from '../../model/Category';
+import { Category } from '../../entities/Category';
 import { ICategoriesRepository } from '../../repositories/ICategoriesRepository';
 
 class ListCategoriesUseCase {

--- a/src/modules/cars/useCases/listCategories/index.ts
+++ b/src/modules/cars/useCases/listCategories/index.ts
@@ -2,7 +2,7 @@ import { CategoriesRepository } from '../../repositories/implementations/Categor
 import { ListCategoriesController } from './ListCategoriesController';
 import { ListCategoriesUseCase } from './ListCategoriesUseCase';
 
-const categoriesRepository = CategoriesRepository.getInstance();
+const categoriesRepository = null;
 const listCategoriesUseCase = new ListCategoriesUseCase(categoriesRepository);
 const listCategoriesController = new ListCategoriesController(
   listCategoriesUseCase

--- a/src/routes/categories.routes.ts
+++ b/src/routes/categories.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import multer from 'multer';
 
-import { createCategoryController } from '../modules/cars/useCases/createCategory';
+import createCategoryController from '../modules/cars/useCases/createCategory';
 import { importCategoryController } from '../modules/cars/useCases/importCategory';
 import { listCategoriesController } from '../modules/cars/useCases/listCategories';
 
@@ -12,7 +12,7 @@ const upload = multer({
 });
 
 categoriesRoutes.post('/', (request, response) => {
-  return createCategoryController.handle(request, response);
+  return createCategoryController().handle(request, response);
 });
 
 categoriesRoutes.get('/', (request, response) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,10 @@
 import express from 'express';
 import swaggerUi from 'swagger-ui-express';
 
+import './database';
+
 import { router } from './routes';
 import swaggerFile from './swagger.json';
-
-import './database';
 
 const PORT = 3333;
 


### PR DESCRIPTION
- Fix model calls to entity
- Configure the entities in typeorm
- Reference the category table to the category entity
- Removes the instantiation of a local repository to use the database in the application, using typeorm.
- Put the use cases of creating a category in a function, so that is called only when registering a category.
- This allows for proper connection to the database and corrects the error where the repository was instantiated even before the database was up.